### PR TITLE
make result set unique by value

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ Usage
 2.  Type any part of any previous command and then:
 
     * Press the UP arrow key to select the nearest command that (1) contains
-      your query and (2) is older than the current command in the command
-      history.
+      your query (2) is older and (3) different than the current command in the
+      command history.
 
-    * Press the DOWN arrow key to select the nearest command that (1)
-      contains your query and (2) is newer than the current command in the
+    * Press the DOWN arrow key to select the nearest command that (1) contains
+      your query (2) is newer and (3) different than the current command in the
       command history.
 
     * Press ^U (the Control and U keys simultaneously) to abort the search.


### PR DESCRIPTION
Hey there.

I often noticed that when I have a history like this:

ax
a
b
a
b
a

and I search for "a", I have to skip through a bunch of "a"s there until I reach "ax", because duplicate history lines are not filtered out from the set of line numbers. I think this is never what the user wants, when another search is executed we can assume the current line is not the desired one.

So this patch makes sure no two subsequent lines in the result set are the same.

Please note I'm sure there are nicer and less boilerplate-y ways to do this, but this was the only one I could come up with. Zsh doesn't offer much for uniqueness of associative arrays.
