### PR TITLE
GH-19: Respect the HIST_FIND_NO_DUPS option.

### DIFF
--- a/zsh-history-substring-search.zsh
+++ b/zsh-history-substring-search.zsh
@@ -200,12 +200,10 @@ function _history-substring-search-begin() {
     #
     # Find all occurrences of the search query in the history file.
     #
-    # (k) turns it an array of line numbers.
+    # (k) returns the "keys" (history index numbers) instead of the values
+    # (Oa) reverses the order, because (R) returns results reversed.
     #
-    # (on) seems to remove duplicates, which are default
-    #      options. They can be turned off by (ON).
-    #
-    _history_substring_search_matches=(${(kon)history[(R)(#$HISTORY_SUBSTRING_SEARCH_GLOBBING_FLAGS)*${_history_substring_search_query_escaped}*]})
+    _history_substring_search_matches=(${(kOa)history[(R)(#$HISTORY_SUBSTRING_SEARCH_GLOBBING_FLAGS)*${_history_substring_search_query_escaped}*]})
 
     #
     # Define the range of values that $_history_substring_search_match_index

--- a/zsh-history-substring-search.zsh
+++ b/zsh-history-substring-search.zsh
@@ -205,6 +205,15 @@ function _history-substring-search-begin() {
     #
     _history_substring_search_matches=(${(kOa)history[(R)(#$HISTORY_SUBSTRING_SEARCH_GLOBBING_FLAGS)*${_history_substring_search_query_escaped}*]})
 
+    # Remove duplicate entries (keeping on the most recent) if HIST_FIND_NO_DUPS is set.
+    if [[ -o HIST_FIND_NO_DUPS ]]; then
+        local -A unique_matches
+        for n in $_history_substring_search_matches; do
+            unique_matches[${history[$n]}]="$n"
+        done
+        _history_substring_search_matches=(${(@n)unique_matches})
+    fi
+
     #
     # Define the range of values that $_history_substring_search_match_index
     # can take: [0, $_history_substring_search_matches_count_plus].


### PR DESCRIPTION
I've been using this locally for about a week now and it seems to work fine.

But as I mentioned in the commit message, I'm no ZSH scripting expert. There could be a much more efficient way of doing the pruning. I looked for a long time for a way to remove the explicit loop, but never found one.

This is also my first time doing a GitHub pull request, so let me know if I messed anything up. Thanks.