### PR TITLE
 history-substring-search-up on an empty line

### DIFF
--- a/zsh-history-substring-search.zsh
+++ b/zsh-history-substring-search.zsh
@@ -205,15 +205,6 @@ function _history-substring-search-begin() {
     #
     _history_substring_search_matches=(${(kOa)history[(R)(#$HISTORY_SUBSTRING_SEARCH_GLOBBING_FLAGS)*${_history_substring_search_query_escaped}*]})
 
-    # Remove duplicate entries (keeping on the most recent) if HIST_FIND_NO_DUPS is set.
-    if [[ -o HIST_FIND_NO_DUPS ]]; then
-        local -A unique_matches
-        for n in $_history_substring_search_matches; do
-            unique_matches[${history[$n]}]="$n"
-        done
-        _history_substring_search_matches=(${(@n)unique_matches})
-    fi
-
     #
     # Define the range of values that $_history_substring_search_match_index
     # can take: [0, $_history_substring_search_matches_count_plus].
@@ -477,6 +468,18 @@ function _history-substring-search-up-search() {
     # We are at the beginning of history and there are no further matches.
     #
     _history-substring-search-not-found
+    return
+  fi
+
+  #
+  # When HIST_FIND_NO_DUPS is set, meaning that only unique command lines from
+  # history should be matched, make sure the new and old results are different.
+  #
+  if [[ -o HIST_FIND_NO_DUPS && $BUFFER == $_history_substring_search_result ]]; then
+    #
+    # Repeat the current search so that a different (unique) match is found.
+    #
+    _history-substring-search-up-search
   fi
 }
 
@@ -561,6 +564,18 @@ function _history-substring-search-down-search() {
     # We are at the end of history and there are no further matches.
     #
     _history-substring-search-not-found
+    return
+  fi
+
+  #
+  # When HIST_FIND_NO_DUPS is set, meaning that only unique command lines from
+  # history should be matched, make sure the new and old results are different.
+  #
+  if [[ -o HIST_FIND_NO_DUPS && $BUFFER == $_history_substring_search_result ]]; then
+    #
+    # Repeat the current search so that a different (unique) match is found.
+    #
+    _history-substring-search-down-search
   fi
 }
 


### PR DESCRIPTION
Hello,

I have this code in my zsh initialization:

```
#!/bin/zsh

# From Prezto Readme
#  If this module is used in conjuncture with the
#  syntax-highlighting module, it must be loaded after it.
source /usr/share/zsh/site-contrib/zsh-history-substring-search/zsh-history-substring-search.zsh

# got the below from prezto history-substring-search module

# Vi
bindkey -M vicmd "k" history-substring-search-up
bindkey -M vicmd "j" history-substring-search-down

bindkey -M viins "$terminfo[kcuu1]" history-substring-search-up
bindkey -M viins "$terminfo[kcud1]" history-substring-search-down

# vim: set filetype=zsh shiftwidth=3 tabstop=3 expandtab fileformat=unix
```

Until recently, When I have an empty line and press 'k', it would show me the previous history command. Now, it seems to go into some kind of processing. I have to press Control-C to break out of the processing. 

If I type something and press 'k', it shows the previous history command that matched (expected behaviour)

It is only when I press 'k' without typing anything that it goes into this unresponsive state.

Just want to check if anyone has noticed this behaviour and if there is any way to get the processing to be:

When empty line, just show the previous history line. When non-empty line, show the history command that matches.

Thanks

