### PR TITLE
Revert "drop oh-my-zsh config file: they supply their own"

### DIFF
--- a/zsh-history-substring-search.plugin.zsh
+++ b/zsh-history-substring-search.plugin.zsh
@@ -1,0 +1,12 @@
+# This file integrates the zsh-history-substring-search script into oh-my-zsh.
+
+source "${0:r:r}.zsh"
+
+if test "$CASE_SENSITIVE" = true; then
+  unset HISTORY_SUBSTRING_SEARCH_GLOBBING_FLAGS
+fi
+
+if test "$DISABLE_COLOR" = true; then
+  unset HISTORY_SUBSTRING_SEARCH_HIGHLIGHT_FOUND
+  unset HISTORY_SUBSTRING_SEARCH_HIGHLIGHT_NOT_FOUND
+fi

--- a/zsh-history-substring-search.plugin.zsh
+++ b/zsh-history-substring-search.plugin.zsh
@@ -1,4 +1,6 @@
-# This file integrates the zsh-history-substring-search script into oh-my-zsh.
+# This file configures zsh-history-substring-search as a plugin so it can
+# be loaded by oh-my-zsh-compatible ZSH frameworks like zgen, antigen and
+# zplug.
 
 source "${0:r:r}.zsh"
 


### PR DESCRIPTION
Restores `zsh-history-substring-search.plugin.zsh`.

oh-my-zsh is not the only zsh framework that uses .plugin.zsh files. Many other frameworks like [Antigen](https://github.com/Tarrasch/antigen-hs), [zplug](https://github.com/b4b4r07/zplug) and [zgen](https://github.com/tarjoilija/zgen) for example all read them to be compatible with plugins written for oh-my-zsh.

Closes #48