### PR TITLE
add *.zwc to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# zsh word code files (zcompile)
+*.zwc


### PR DESCRIPTION
This will prevent the dirty 'untracked content' messages when using this as a submodule (and when zcompiled).

This is practiced in other zsh-users repositories.