### PR TITLE
Option to ensure unique results

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,16 +104,16 @@ default values only after having loaded this script into your ZSH session.
 
 * HISTORY_SUBSTRING_SEARCH_ENSURE_UNIQUE is a global variable that defines
   whether all search results returned are _unique_. If set to a non-empty
-  value, then only unique search results are presented. It is unset by
-  default. An alternative way to ensure that search results are unique is
-  to use `setopt HIST_IGNORE_ALL_DUPS`. If both this configuration variable
-  and `setopt HIST_IGNORE_ALL_DUPS` are unset, then `setopt HIST_FIND_NO_DUPS`
-  is still respected, and makes this plugin skip duplicate _adjacent_ search
+  value, then only unique search results are presented. This behaviour is off
+  by default. An alternative way to ensure that search results are unique is
+  to use `setopt HIST_IGNORE_ALL_DUPS`. If this configuration variable is off
+  and `setopt HIST_IGNORE_ALL_DUPS` is unset, then `setopt HIST_FIND_NO_DUPS`
+  is still respected and it makes this plugin skip duplicate _adjacent_ search
   results as you cycle through them, but this does not guarantee that search
   results are unique: if your search results were "Dog", "Dog", "HotDog",
   "Dog", then cycling them gives "Dog", "HotDog", "Dog". Notice that the "Dog"
   search result appeared twice as you cycled through them. If you wish to
-  receive globally unique search results only once, then set this
+  receive globally unique search results only once, then use this
   configuration variable, or use `setopt HIST_IGNORE_ALL_DUPS`.
 
 ------------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -102,13 +102,19 @@ default values only after having loaded this script into your ZSH session.
   Flags" section in the zshexpn(1) man page to learn about the kinds of
   values you may assign to this variable.
 
-To always receive _unique_ search results, use `setopt HIST_IGNORE_ALL_DUPS`.
-Alternatively, use `setopt HIST_FIND_NO_DUPS` which makes this plugin skip
-duplicate _adjacent_ search results as you cycle through them---however, this
-does not guarantee that search results are unique: if your search results were
-"Dog", "Dog", "HotDog", "Dog", then cycling them gives "Dog", "HotDog", "Dog".
-Notice that the "Dog" search result appeared twice as you cycled through them!
-If you wish to avoid this limitation, then use `setopt HIST_IGNORE_ALL_DUPS`.
+* HISTORY_SUBSTRING_SEARCH_ENSURE_UNIQUE is a global variable that defines
+  whether all search results returned are _unique_. If set to a non-empty
+  value, then only unique search results are presented. It is unset by
+  default. An alternative way to ensure that search results are unique is
+  to use `setopt HIST_IGNORE_ALL_DUPS`. If both this configuration variable
+  and `setopt HIST_IGNORE_ALL_DUPS` are unset, then `setopt HIST_FIND_NO_DUPS`
+  is still respected, and makes this plugin skip duplicate _adjacent_ search
+  results as you cycle through them, but this does not guarantee that search
+  results are unique: if your search results were "Dog", "Dog", "HotDog",
+  "Dog", then cycling them gives "Dog", "HotDog", "Dog". Notice that the "Dog"
+  search result appeared twice as you cycled through them. If you wish to
+  receive globally unique search results only once, then set this
+  configuration variable, or use `setopt HIST_IGNORE_ALL_DUPS`.
 
 ------------------------------------------------------------------------------
 History

--- a/zsh-history-substring-search.zsh
+++ b/zsh-history-substring-search.zsh
@@ -190,6 +190,11 @@ _history-substring-search-begin() {
     return;
   fi
 
+  #
+  # Clear the previous result.
+  #
+  _history_substring_search_result=''
+
   if [[ -z $BUFFER ]]; then
     #
     # If the buffer is empty, we will just act like up-history/down-history

--- a/zsh-history-substring-search.zsh
+++ b/zsh-history-substring-search.zsh
@@ -45,7 +45,7 @@
 HISTORY_SUBSTRING_SEARCH_HIGHLIGHT_FOUND='bg=magenta,fg=white,bold'
 HISTORY_SUBSTRING_SEARCH_HIGHLIGHT_NOT_FOUND='bg=red,fg=white,bold'
 HISTORY_SUBSTRING_SEARCH_GLOBBING_FLAGS='i'
-unset HISTORY_SUBSTRING_SEARCH_ENSURE_UNIQUE
+HISTORY_SUBSTRING_SEARCH_ENSURE_UNIQUE=''
 
 #-----------------------------------------------------------------------------
 # the main ZLE widgets


### PR DESCRIPTION
I have seen that his has come up before, but I have made a few patches to enable the plugin to return unique search results even if HIST_IGNORE_ALL_DUPS is not set.

There are good reasons why the user would not want to set HIST_IGNORE_ALL_DUPS. I for one like to be able to see my precise history. Also for plugins like zsh-autosuggestions, it is helpful to be able to analyse the history context when generating suggestions, which would be hopeless if older duplicate entries were later removed.

The implementation uses lazy evaluation to compute the next unique result only when it is required, so the response time is still snappy. It also observes HIST_IGNORE_ALL_DUPS and if it is set it does no further processing, so if you are using that option you should perceive no change.

Would you be interested in merging this?

Thanks,
Geza