### PR TITLE
Add an option to preserve the cursor position

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,12 @@ default values only after having loaded this script into your ZSH session.
   receive globally unique search results only once, then use this
   configuration variable, or use `setopt HIST_IGNORE_ALL_DUPS`.
 
+* `HISTORY_SUBSTRING_SEARCH_PRESERVE_CURSOR_POSITION` is a global variable
+  that defines whether or not the cursor position will be preserved where the
+  search occurred or if the cursor position moves to the end of the line. The
+  default behavior is to move to the end of the line. If set to a non-empty
+  value, the cursor position is preserved.
+
 
 History
 ------------------------------------------------------------------------------

--- a/zsh-history-substring-search.zsh
+++ b/zsh-history-substring-search.zsh
@@ -47,6 +47,7 @@ typeset -g HISTORY_SUBSTRING_SEARCH_HIGHLIGHT_FOUND
 typeset -g HISTORY_SUBSTRING_SEARCH_HIGHLIGHT_NOT_FOUND
 typeset -g HISTORY_SUBSTRING_SEARCH_GLOBBING_FLAGS
 typeset -g HISTORY_SUBSTRING_SEARCH_ENSURE_UNIQUE
+typeset -g HISTORY_SUBSTRING_SEARCH_PRESERVE_CURSOR_POSITION
 typeset -g _history_substring_search_refresh_display
 typeset -g _history_substring_search_query_highlight
 typeset -g _history_substring_search_result
@@ -65,6 +66,7 @@ typeset -g HISTORY_SUBSTRING_SEARCH_HIGHLIGHT_FOUND='bg=magenta,fg=white,bold'
 typeset -g HISTORY_SUBSTRING_SEARCH_HIGHLIGHT_NOT_FOUND='bg=red,fg=white,bold'
 typeset -g HISTORY_SUBSTRING_SEARCH_GLOBBING_FLAGS='i'
 typeset -g HISTORY_SUBSTRING_SEARCH_ENSURE_UNIQUE=''
+typeset -g HISTORY_SUBSTRING_SEARCH_PRESERVE_CURSOR_POSITION=''
 typeset -g _history_substring_search_{refresh_display,query_highlight,result,query,match_index,raw_match_index}
 typeset -ga _history_substring_search{,_raw}_matches
 
@@ -287,7 +289,7 @@ _history-substring-search-begin() {
   # decremented to 0.
   #
   if [[ $WIDGET == history-substring-search-down ]]; then
-     _history_substring_search_match_index=1
+    _history_substring_search_match_index=1
   else
     _history_substring_search_match_index=0
   fi
@@ -298,11 +300,17 @@ _history-substring-search-end() {
 
   _history_substring_search_result=$BUFFER
 
-  # the search was successful so display the result properly by clearing away
-  # existing highlights and moving the cursor to the end of the result buffer
+  # the search was successful so display the result properly by clearing away existing highlights
   if [[ $_history_substring_search_refresh_display -eq 1 ]]; then
     region_highlight=()
-    CURSOR=${#BUFFER}
+
+    #
+    # If HISTORY_SUBSTRING_SEARCH_PRESERVE_CURSOR_POSITION is not empty
+    # move the cursor to the end of the result buffer.
+    #
+    if [[ -z $HISTORY_SUBSTRING_SEARCH_PRESERVE_CURSOR_POSITION ]]; then
+      CURSOR=${#BUFFER}
+    fi
   fi
 
   # highlight command line using zsh-syntax-highlighting


### PR DESCRIPTION
When $HISTORY_SUBSTRING_SEARCH_PRESERVE_CURSOR_POSITION is non-empty the cursor position will be preserved in searches instead of moving the cursor position to the end of the line.

This enables behavior that is more familiar to users (like me) who came from bash's `history-search-forward` and `history-search-backward` behavior.

---

For example, if history is:

```
1. echo one
2. echo two
3. echo three
```

Examples below show the cursor position before pressing up as `[]`.

Default behavior is unchanged:

```
# With no text it still shows the previous command and moves to end.
$ []
$ echo[]

# With a substring it searches and moves to end.
$ echo[]
$ echo three[]
$ echo two[]
$ echo one[]
$ echo[]
```

Behavior with HISTORY_SUBSTRING_SEARCH_PRESERVE_CURSOR_POSITION=1:

```
# With no text it still shows the previous command and moves to end.
$ []
$ echo[]

# With a substring it searches and keeps the cursor position unchanged.
$ echo[]
$ echo[] three
$ echo[] two
$ echo[] one
$ echo[]
```