### PR TITLE
also ignore files ending in .zwc.old

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-# zsh word code files (zcompile)
-*.zwc
+# zsh word code files (zcompile and zrecompile)
+*.zwc*


### PR DESCRIPTION
zrecompile moves old files before creating new ones