### PR TITLE
Support anchoring the substring to search for

### DIFF
--- a/zsh-history-substring-search.zsh
+++ b/zsh-history-substring-search.zsh
@@ -48,6 +48,7 @@ typeset -g HISTORY_SUBSTRING_SEARCH_HIGHLIGHT_NOT_FOUND='bg=red,fg=white,bold'
 typeset -g HISTORY_SUBSTRING_SEARCH_GLOBBING_FLAGS='i'
 typeset -g HISTORY_SUBSTRING_SEARCH_ENSURE_UNIQUE=''
 typeset -g HISTORY_SUBSTRING_SEARCH_FUZZY=''
+typeset -g HISTORY_SUBSTRING_SEARCH_ANCHORED=''
 
 #-----------------------------------------------------------------------------
 # declare internal global variables

--- a/zsh-history-substring-search.zsh
+++ b/zsh-history-substring-search.zsh
@@ -246,7 +246,13 @@ _history-substring-search-begin() {
     # Escape and join query parts with wildcard character '*' as seperator
     # `(j:CHAR:)` join array to string with CHAR as seperator
     #
-    local search_pattern="*${(j:*:)_history_substring_search_query_parts[@]//(#m)[\][()|\\*?#<>~^]/\\$MATCH}*"
+    local search_pattern="${(j:*:)_history_substring_search_query_parts[@]//(#m)[\][()|\\*?#<>~^]/\\$MATCH}*"
+    #
+    # Support anchoring history search to the beginning of the command
+    # 
+    if [[ -z $HISTORY_SUBSTRING_SEARCH_ANCHORED ]]; then
+      search_pattern="*${search_pattern}"
+    fi
 
     #
     # Find all occurrences of the search pattern in the history file.


### PR DESCRIPTION
Add a new optional config variable that will anchor history search to the beginning of the command.

Note that the default behavior does not change with this