### PR TITLE
Don't overwrite config with default values

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Configuration
 ------------------------------------------------------------------------------
 
 This script defines the following global variables. You may override their
-default values only after having loaded this script into your ZSH session.
+default values.
 
 * `HISTORY_SUBSTRING_SEARCH_HIGHLIGHT_FOUND` is a global variable that defines
   how the query should be highlighted inside a matching command. Its default

--- a/zsh-history-substring-search.zsh
+++ b/zsh-history-substring-search.zsh
@@ -43,12 +43,12 @@
 # declare global configuration variables
 #-----------------------------------------------------------------------------
 
-typeset -g HISTORY_SUBSTRING_SEARCH_HIGHLIGHT_FOUND='bg=magenta,fg=white,bold'
-typeset -g HISTORY_SUBSTRING_SEARCH_HIGHLIGHT_NOT_FOUND='bg=red,fg=white,bold'
-typeset -g HISTORY_SUBSTRING_SEARCH_GLOBBING_FLAGS='i'
-typeset -g HISTORY_SUBSTRING_SEARCH_ENSURE_UNIQUE=''
-typeset -g HISTORY_SUBSTRING_SEARCH_FUZZY=''
-typeset -g HISTORY_SUBSTRING_SEARCH_PREFIX=''
+: ${HISTORY_SUBSTRING_SEARCH_HIGHLIGHT_FOUND='bg=magenta,fg=white,bold'}
+: ${HISTORY_SUBSTRING_SEARCH_HIGHLIGHT_NOT_FOUND='bg=red,fg=white,bold'}
+: ${HISTORY_SUBSTRING_SEARCH_GLOBBING_FLAGS='i'}
+: ${HISTORY_SUBSTRING_SEARCH_ENSURE_UNIQUE=''}
+: ${HISTORY_SUBSTRING_SEARCH_FUZZY=''}
+: ${HISTORY_SUBSTRING_SEARCH_PREFIX=''}
 
 #-----------------------------------------------------------------------------
 # declare internal global variables


### PR DESCRIPTION
otherwise users are obliged to set the config values *after* sourcing the plugin. They're not able to do it before. Also, re-sourcing the plugin will reset the values to the defaults again.

A similar change was done in zsh-autosuggestions in the past: https://github.com/zsh-users/zsh-autosuggestions/commit/9e4d3c3