### PR TITLE
Symlink instead of file

### DIFF
--- a/zsh-history-substring-search.plugin.zsh
+++ b/zsh-history-substring-search.plugin.zsh
@@ -1,2 +1,1 @@
-0=${(%):-%N}
-source ${0:A:h}/zsh-history-substring-search.zsh
+zsh-history-substring-search.zsh


### PR DESCRIPTION
`${0}` not compatible with some zsh plugin managers