### PR TITLE
Docs: Replace nbsp with space

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Usage
 
     Users typically bind their UP and DOWN arrow keys to this script, thus:
     * Run `cat -v` in your favorite terminal emulator to observe key codes.
-      (**NOTE:** In some cases, `cat -v` shows the wrong key codes.  If the
+      (**NOTE:** In some cases, `cat -v` shows the wrong key codes.  If the
       key codes shown by `cat -v` don't work for you, press `<C-v><UP>` and
       `<C-v><DOWN>` at your ZSH command line prompt for correct key codes.)
     * Press the UP arrow key and observe what is printed in your terminal.


### PR DESCRIPTION
There are some `&nbsp;`s in the `README.md`.

These `&nbsp;` in the `.md` file tend to break some Markdown parsers.

Here is an example of how `VS Code` parses the text:

Before | After 
:-:|:-:
![image](https://user-images.githubusercontent.com/46739/150944379-98706a84-2b1c-43b4-9621-b7b2c814dd6b.png) | ![](https://user-images.githubusercontent.com/46739/150943524-a27e2d1d-535d-462a-b596-95afd98c1afd.png) 

