### PR TITLE
Add Fig as an installation method to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ Using the [Homebrew]( https://brew.sh ) package manager:
     brew install zsh-history-substring-search
     echo 'source /usr/local/share/zsh-history-substring-search/zsh-history-substring-search.zsh' >> ~/.zshrc
 
+Using [Fig](https://fig.io):
+
+Fig adds apps, shortcuts, and autocomplete to your existing terminal.
+
+Install `Powerlevel10k` in just one click.
+
+<a href="https://fig.io/plugins/other/powerlevel10k" target="_blank"><img src="https://fig.io/badges/install-with-fig.svg" /></a>
+
 Using [Oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh):
 
 1. Clone this repository in oh-my-zsh's plugins directory:

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ Using [Fig](https://fig.io):
 
 Fig adds apps, shortcuts, and autocomplete to your existing terminal.
 
-Install `Powerlevel10k` in just one click.
+Install `zsh-history-substring-searc` in just one click.
 
-<a href="https://fig.io/plugins/other/powerlevel10k" target="_blank"><img src="https://fig.io/badges/install-with-fig.svg" /></a>
+<a href="https://fig.io/plugins/other/zsh-history-substring-search" target="_blank"><img src="https://fig.io/badges/install-with-fig.svg" /></a>
 
 Using [Oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh):
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Using [Fig](https://fig.io):
 
 Fig adds apps, shortcuts, and autocomplete to your existing terminal.
 
-Install `zsh-history-substring-searc` in just one click.
+Install `zsh-history-substring-search` in just one click.
 
 <a href="https://fig.io/plugins/other/zsh-history-substring-search" target="_blank"><img src="https://fig.io/badges/install-with-fig.svg" /></a>
 


### PR DESCRIPTION

The [Fig Plugin Store](https://fig.io/plugins) supports 1-click install for 400+ shell plugins. We have over 100k users, thousands of whom manage their shell configuration with Fig.

Zsh history substring search is already listed in the store so we'd love to have it listed as a download method on your readme.

Thanks so much and please let me know if you have any questions!
