### PR TITLE
replace sourcing method with `exec zsh`

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ Using [Oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh):
 
         plugins=( [plugins...] zsh-history-substring-search)
 
-3. Source `~/.zshrc`  to take changes into account:
+3. Run `exec zsh`  to take changes into account:
 
-        source ~/.zshrc
+        exec zsh
 
 Usage
 ------------------------------------------------------------------------------


### PR DESCRIPTION
Sourcing `.zshrc` may cause trouble because some things that are already in the zsh session haven't been removed.

Reference: https://github.com/ohmyzsh/ohmyzsh/wiki/FAQ#how-do-i-reload-the-zshrc-file