### PR TITLE
fix search match highlight with latest z-sy-h

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,9 @@ default values.
   receive globally unique search results only once, then use this
   configuration variable, or use `setopt HIST_IGNORE_ALL_DUPS`.
 
+* `HISTORY_SUBSTRING_SEARCH_HIGHLIGHT_TIMEOUT` is a global variable that
+  defines a timeout in seconds for clearing the search highlight.
+
 
 History
 ------------------------------------------------------------------------------

--- a/zsh-history-substring-search.zsh
+++ b/zsh-history-substring-search.zsh
@@ -408,6 +408,23 @@ _history-substring-search-end() {
   # zle -R "mn: "$_history_substring_search_match_index" m#: "${#_history_substring_search_matches}
   # read -k -t 200 && zle -U $REPLY
 
+  #
+  # When this function returns, z-sy-h runs its line-pre-redraw hook. It has no
+  # logic for determining highlight priority, when two different memo= marked
+  # region highlights overlap; instead, it always prioritises itself. Below is
+  # a workaround for dealing with it.
+  #
+  if [[ $_history_substring_search_zsh_5_9 -eq 1 ]]; then
+    zle -R
+    #
+    # After line redraw with desired highlight, wait for timeout or user input
+    # before removing search highlight and exiting. This ensures no highlights
+    # are left lingering after search is finished.
+    #
+    read -k -t ${HISTORY_SUBSTRING_SEARCH_HIGHLIGHT_TIMEOUT:-1} && zle -U $REPLY
+    region_highlight=( "${(@)region_highlight:#*${highlight_memo}*}" )
+  fi
+
   # Exit successfully from the history-substring-search-* widgets.
   return 0
 }


### PR DESCRIPTION
This fixes match portion highlighting when using latest zsh-syntax-highlighting widget.

~Fixes~ Concerns #131 

~Disclaimer: I'm not quite sure why this works, or how it's supposed to work. Feel free to modify this patch as you see fit.~

~This is definitely not a proper fix, just poorly masking some issue elsewhere. I'm leaving it here for now, but it shouldn't be merged.~

This should now be good for review. As far as a workaround goes, anyway.