### PR TITLE
Fix user input after search

### DIFF
--- a/zsh-history-substring-search.zsh
+++ b/zsh-history-substring-search.zsh
@@ -406,7 +406,7 @@ _history-substring-search-end() {
 
   # For debugging purposes:
   # zle -R "mn: "$_history_substring_search_match_index" m#: "${#_history_substring_search_matches}
-  # read -k -t 200 && zle -U -- $REPLY
+  # read -k -t 200 && zle -U -- "$REPLY"
 
   #
   # When this function returns, z-sy-h runs its line-pre-redraw hook. It has no
@@ -421,7 +421,7 @@ _history-substring-search-end() {
     # before removing search highlight and exiting. This ensures no highlights
     # are left lingering after search is finished.
     #
-    read -k -t ${HISTORY_SUBSTRING_SEARCH_HIGHLIGHT_TIMEOUT:-1} && zle -U -- $REPLY
+    read -k -t ${HISTORY_SUBSTRING_SEARCH_HIGHLIGHT_TIMEOUT:-1} && zle -U -- "$REPLY"
     region_highlight=( "${(@)region_highlight:#*${highlight_memo}*}" )
   fi
 

--- a/zsh-history-substring-search.zsh
+++ b/zsh-history-substring-search.zsh
@@ -406,7 +406,7 @@ _history-substring-search-end() {
 
   # For debugging purposes:
   # zle -R "mn: "$_history_substring_search_match_index" m#: "${#_history_substring_search_matches}
-  # read -k -t 200 && zle -U $REPLY
+  # read -k -t 200 && zle -U -- $REPLY
 
   #
   # When this function returns, z-sy-h runs its line-pre-redraw hook. It has no
@@ -421,7 +421,7 @@ _history-substring-search-end() {
     # before removing search highlight and exiting. This ensures no highlights
     # are left lingering after search is finished.
     #
-    read -k -t ${HISTORY_SUBSTRING_SEARCH_HIGHLIGHT_TIMEOUT:-1} && zle -U $REPLY
+    read -k -t ${HISTORY_SUBSTRING_SEARCH_HIGHLIGHT_TIMEOUT:-1} && zle -U -- $REPLY
     region_highlight=( "${(@)region_highlight:#*${highlight_memo}*}" )
   fi
 


### PR DESCRIPTION
Now when a user types `-` or `<space>` directly after searching, it is not treated as a commandline option by `zle`

Fixes #154 