### PR TITLE
HISTORY_SUBSTRING_SEARCH_ENSURE_UNIQUE is now forces search unique result

### DIFF
--- a/zsh-history-substring-search.zsh
+++ b/zsh-history-substring-search.zsh
@@ -556,7 +556,7 @@ _history_substring_search_process_raw_matches() {
     # When HIST_IGNORE_ALL_DUPS is set, ZSH already ensures a unique history,
     # so in this case we do not need to do anything.
     #
-    if [[ ! -o HIST_IGNORE_ALL_DUPS && -n $HISTORY_SUBSTRING_SEARCH_ENSURE_UNIQUE ]]; then
+    if [[ -n $HISTORY_SUBSTRING_SEARCH_ENSURE_UNIQUE ]]; then
       #
       # Get the actual history entry at the new index, and check if we have
       # already added it to _history_substring_search_matches.


### PR DESCRIPTION
Because HIST_IGNORE_ALL_DUPS cant actually remove all dups with APPEND_HISTORY, INC_APPEND_HISTORY and SHARED_HISTORY options, it is better to have this options actually "ensure" if history got only unique elements. Now it will do that with any state of HIST_IGNORE_ALL_DUPS zsh setting