### PR TITLE
Fix zplug syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Using [zplug](https://github.com/zplug/zplug):
 
 1. Add this repo to `~/.zshrc`:
 
-        zplug "zsh-users/zsh-history-substring-search", as: plugin
+        zplug "zsh-users/zsh-history-substring-search", as:plugin
 
 Using [antigen](https://github.com/zsh-users/antigen):
 


### PR DESCRIPTION
The space before "plugin" raises an error: `[zplug] ERROR: |as| as tag must be [plugin, command, theme]`.

This tripped me up initially after copy/pasting this line.