### PR TITLE
Make "up-arrow" handling consistent with or without a substring search

### DIFF
--- a/zsh-history-substring-search.zsh
+++ b/zsh-history-substring-search.zsh
@@ -499,6 +499,11 @@ _history-substring-search-up-history() {
       BUFFER=
 
     # going up from somewhere below the top of history
+    # the cursor is at the end of a multiline prompt, go up in history.
+    elif [[ $CURSOR -eq $#BUFFER ]] then
+      zle up-history
+
+    # Otherwise, keep the default behavior of up arrow.
     else
       zle up-line-or-history
     fi


### PR DESCRIPTION
Currently up arrow behaves like "up-history" in substring search mode, and "up-line-or-history" when there's no substring. This causes inconsistency with multiline commands. 

Fish behaves in the same way for both cases.